### PR TITLE
[fix]UserControllerのcreateアクションにトランザクション処理を追加

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -12,19 +12,26 @@ class Api::V1::UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
-    if @user.save
-      # Create user profile when user account is created
-      profile = Profile.new
-      profile.user_id = @user.id
-      if profile.save
-        user_serializer = parse_json(@user)
-        render json: user_serializer, status: :created
-      else
-        @user.destroy
-        render json: { errors: profile.errors }, status: :unprocessable_entity
+    # User model and Profile related to user need to be registered at the same time
+    begin
+      ActiveRecord::Base.transaction do
+        if @user.save
+          # Continue to create user profile when user account is created
+          @profile = Profile.new
+          @profile.user_id = @user.id
+          if @profile.save
+            user_serializer = parse_json(@user)
+            render json: user_serializer, status: :created
+          else
+            raise ActiveRecord::RecordInvalid
+          end
+        else
+          render json: { errors: @user.errors }, status: :unprocessable_entity
+        end
       end
-    else
-      render json: { errors: @user.errors }, status: :unprocessable_entity
+    rescue => exception
+      logger.debug("Profile model isn't created although user model is created: #{exception}")
+      render json: { errors: @profile.errors }, status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
### 概要

ユーザーの新規登録時にUser ModelとProfile model を同時作成するアクションを記載しているが、どちらかの処理でエラーが発生した場合にデータベース上にデータ不整合が生じる。
例えば、user modelが作成されたにもかかわらずprofilemodelのバリデーションで失敗した場合に、再度ユーザーが登録しようとすると、Usermodelが既に登録されているためEmailの一意性バリーデーションにより再度登録できなくなる。

### 変更点
---

- User controllerにトランザクション処理を追加

### 参照
---


### 備考
---