### PR TITLE
[fix]update exhibit controller update action to reload pictures data after updating #28

### DIFF
--- a/app/controllers/api/v1/exhibits_controller.rb
+++ b/app/controllers/api/v1/exhibits_controller.rb
@@ -47,8 +47,9 @@ class Api::V1::ExhibitsController < ApplicationController
     begin
       @exhibit.pictures.destroy_all
       if Picture.create_pictures(@exhibit.id, params[:exhibit])
+        @exhibit.reload
         exhibit_serializer = parse_json(@exhibit)
-        render json: exhibit_serializer, status: :created
+        render json: exhibit_serializer, status: :ok
       else
         logger.debug("failed to save all pictures")
         raise ActiveRecord::RecordInvalid

--- a/app/controllers/api/v1/multi_exhibits_controller.rb
+++ b/app/controllers/api/v1/multi_exhibits_controller.rb
@@ -32,7 +32,7 @@ class Api::V1::MultiExhibitsController < ApplicationController
   private
 
   def multi_exhibit_params
-    params.require(:multi_exhibit).permit(:exhibit_id, :lang, :name, :description)
+    params.require(:multi_exhibit).permit(:id, :exhibit_id, :lang, :name, :description)
   end
 
   def set_multi_exhibit

--- a/app/serializers/exhibit_serializer.rb
+++ b/app/serializers/exhibit_serializer.rb
@@ -16,6 +16,7 @@ class ExhibitSerializer < ActiveModel::Serializer
   #   multi_exhibits: [
   #     {
   #       id: multi_exhibit_id,
+  #       exhibit_id: exhibit_id
   #       lang: "ja",
   #       name: "xxxx",
   #       description: "xxxx"

--- a/app/serializers/multi_exhibit_serializer.rb
+++ b/app/serializers/multi_exhibit_serializer.rb
@@ -1,3 +1,3 @@
 class MultiExhibitSerializer < ActiveModel::Serializer
-  attributes :id, :lang, :name, :description
+  attributes :id, :exhibit_id, :lang, :name, :description
 end


### PR DESCRIPTION
### 概要

フロントエンドとの連携において、画像更新処理後に画像がアップデートされずに表示できない問題が発生。
Exhibit controllerのupdateアクションにて、更新処理後にデータがreloadされずレスポンスを返していることが判明し修正。 