### PR TITLE
Feature/user exhibit dev #39

### DIFF
--- a/app/controllers/api/v1/tourist/exhibits_controller.rb
+++ b/app/controllers/api/v1/tourist/exhibits_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Tourist::ExhibitsController < ApplicationController
+  def show
+    spot = User.find(params[:id])
+    exhibits = spot.exhibits
+    exhibit_serializer = parse_json(exhibits)
+    render json: exhibit_serializer, status: :ok
+  end
+end

--- a/app/controllers/api/v1/tourist/spots_controller.rb
+++ b/app/controllers/api/v1/tourist/spots_controller.rb
@@ -7,10 +7,11 @@ class Api::V1::Tourist::SpotsController < ApplicationController
     options = {
       params: {
         last: spots.total_pages,
-        count: params[:items],
-        query: params[:query],
-        category: params[:category],
-        prefecture: params[:prefecture]
+        page: current_page,
+        count: params[:items] ? params[:items] : 0,
+        query: params[:query] ? params[:query] : "",
+        category: params[:category] ? params[:category] : 0,
+        prefecture: params[:prefecture] ? params[:prefecture] : ""
       }
     }
     render json: spots, root: "data", each_serializer: SpotSerializer, meta: options, adapter: :json

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -10,7 +10,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     if Rails.env.production?
       origins 'http://startlens.com.s3-website-ap-northeast-1.amazonaws.com/'
     else
-      origins 'http://localhost:4000'
+      origins '*'
     end
 
     resource '*',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
       namespace :tourist do
         resources :spots, only: [:index]
+        resources :exhibits, only: [:show]
       end
     end
   end

--- a/spec/requests/api/v1/tourist/exhibits_request_spec.rb
+++ b/spec/requests/api/v1/tourist/exhibits_request_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Tourist::Exhibits", type: :request do
+  describe "GET /api/v1/tourist/exhibit/:id" do
+    before do
+      @user = FactoryBot.create(:user)
+      @exhibit = FactoryBot.create(:exhibit, user_id: @user.id)
+      @exhibit2 = FactoryBot.create(:exhibit2, user_id: @user.id)
+      multi_exhibit = FactoryBot.create(:multi_exhibit, exhibit_id: @exhibit.id)
+      multi_exhibit2 = FactoryBot.create(:multi_exhibit2, exhibit_id: @exhibit2.id)
+    end
+
+    it "responds successfully" do
+      get api_v1_tourist_exhibit_url(@user.id)
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json[0]["id"]).to eq @exhibit.id
+      expect(json[1]["id"]).to eq @exhibit2.id
+      expect(json[0]["multiExhibits"].count).to eq 1
+      expect(json[1]["multiExhibits"].count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
### 概要

観光地に紐づくExhibitを取得できるように実装。またフロントエンドとの連携において複数のフロントからアクセスするため開発環境のみCORSの設定をワイルドカードで指定。

詳細は #39　を参照。