### PR TITLE
[add]craete tourist review function #44

### DIFF
--- a/app/controllers/api/v1/tourist/reviews_controller.rb
+++ b/app/controllers/api/v1/tourist/reviews_controller.rb
@@ -1,0 +1,36 @@
+class Api::V1::Tourist::ReviewsController < ApplicationController
+  before_action :check_login_tourist, only: [:create, :destroy]
+  before_action :set_tourist, only: [:destroy]
+  before_action :check_owner, only: [:destroy]
+  before_action :snakeize_params, only: [:create, :destroy]
+
+  def create
+    review = current_tourist.reviews.build(review_params)
+    if review.save
+      review_serializer = parse_json(review)
+      render json: review_serializer, status: :created
+    else
+      logger.debug("Review model isn't created: #{review.errors.messages}")
+      render json: { errors: review.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @review.destroy
+    render json: {}, status: :no_content
+  end
+
+  private
+
+  def review_params
+    params.require(:review).permit(:user_id, :lang, :post_review, :rating)
+  end
+
+  def set_tourist
+    @review = Review.find(params[:id])
+  end
+
+  def check_owner
+    head :forbidden unless @review.tourist_id == current_tourist&.id
+  end
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,10 +1,23 @@
 class Review < ApplicationRecord
 
   validates :user_id, presence: true
-  validates :tourist_id, presence: true
-  validates :lang, presence: true
+  validates :tourist_id, presence: true, uniqueness: { scope: [:user_id], message: "既にレビューが投稿されています。" }
+  validates :lang, presence: { message: "%{attribute}を入力してください。" }
   validates :post_review, presence: { message: "%{attribute}を入力してください。" }
-  validates :rating, presence: { message: "%{attribute}を入力してください。" }
+  validates :rating, presence: { message: "%{attribute}を入力してください。" },
+            numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 5, message: "%{attribute}は0以上5以下の数字を入力してください。"}
 
   belongs_to :tourist
+  belongs_to :user
+
+  def self.review_static(user_id)
+    reviews = self.where(user_id: user_id)
+    count = reviews.count
+
+    if reviews.exists?
+      { average: BigDecimal(reviews.sum(:rating) / count).ceil(1).to_f, count: count }
+    else
+      { average: 0.0, count: 0 }
+    end
+  end
 end

--- a/app/serializers/review_serializer.rb
+++ b/app/serializers/review_serializer.rb
@@ -1,0 +1,3 @@
+class ReviewSerializer < ActiveModel::Serializer
+  attributes :id, :user_id, :tourist_id, :lang, :post_review, :rating, :created_at
+end

--- a/app/serializers/spot_profile_serializer.rb
+++ b/app/serializers/spot_profile_serializer.rb
@@ -1,11 +1,18 @@
 class SpotProfileSerializer < ActiveModel::Serializer
-  attributes :id, :user_id, :major_category, :telephone, :company_site, :url, :rating
+  attributes :id, :user_id, :major_category, :telephone, :company_site, :url, :rating, :rating_count
+
+  attr_accessor :static
 
   def url
     object.thumbnail.url
   end
 
   def rating
-    3.5
+    self.static = Review.review_static(object.user_id)
+    self.static[:average]
+  end
+
+  def rating_count
+    self.static[:count]
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -40,6 +40,10 @@ ja:
         birth: 生年
         country: 国
         lang: 言語
+      review:
+        lang: 言語
+        post_review: レビュー
+        rating: 評価
   errors:
     messages:
       carrierwave_processing_error: 処理できませんでした

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
         get '/load', to: 'tourists#load', as: :load
         resources :spots, only: [:index, :show]
         resources :tourists, only: [:create, :update]
+        resources :reviews, only: [:create, :destroy]
       end
     end
   end

--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -1,5 +1,25 @@
 FactoryBot.define do
   factory :review do
-    
+    association :user
+    association :tourist
+    lang { "ja" }
+    post_review { "ここは最高によかった" }
+    rating { 3 }
+  end
+
+  factory :review2, class: Review do
+    association :user
+    association :tourist
+    lang { "en" }
+    post_review { "Thats awesome" }
+    rating { 5 }
+  end
+
+  factory :review3, class: Review do
+    association :user
+    association :tourist
+    lang { "en" }
+    post_review { "Not bad" }
+    rating { 1 }
   end
 end

--- a/spec/factories/tourists.rb
+++ b/spec/factories/tourists.rb
@@ -11,7 +11,24 @@ FactoryBot.define do
   end
 
   factory :tourist1, class: Tourist do
-    sequence(:email) { |n| "sample#{n}@gmail.com" }
+    sequence(:email) { |n| "example#{n}@gmail.com" }
     password { "sampletest" }
+    username { "テストユーザー" }
+    sex { 1 }
+    birth { 1987 }
+    country { "US" }
+    lang { "en" }
+    is_active { true }
+  end
+
+  factory :tourist2, class: Tourist do
+    sequence(:email) { |n| "test#{n}@gmail.com" }
+    password { "sampletest" }
+    username { "テストユーザー" }
+    sex { 1 }
+    birth { 1987 }
+    country { "US" }
+    lang { "en" }
+    is_active { true }
   end
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,5 +1,90 @@
 require 'rails_helper'
 
 RSpec.describe Review, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "is created" do
+    let(:review) { FactoryBot.create(:review) }
+    let(:user) { FactoryBot.create(:user) }
+    let(:tourist) { FactoryBot.create(:tourist) }
+
+    context "to be valid" do
+      it "with lang, post_review, rating" do
+        expect(build(:review, user_id: user.id, tourist_id: tourist.id)).to be_valid
+      end
+    end
+
+    context "to be invalid" do
+      it "without post_review" do
+        review = build(:review, user_id: user.id, tourist_id: tourist.id, post_review: "")
+        review.valid?
+        expect(review.errors[:post_review]).to include("レビューを入力してください。")
+      end
+
+      it "without lang" do
+        review = build(:review, user_id: user.id, tourist_id: tourist.id, lang: "")
+        review.valid?
+        expect(review.errors[:lang]).to include("言語を入力してください。")
+      end
+
+      it "without rating" do
+        review = build(:review, user_id: user.id, tourist_id: tourist.id, rating: "")
+        review.valid?
+        expect(review.errors[:rating]).to include("評価を入力してください。")
+      end
+
+      it "without rating more than 5" do
+        review = build(:review, user_id: user.id, tourist_id: tourist.id, rating: 6)
+        review.valid?
+        expect(review.errors[:rating]).to include("評価は0以上5以下の数字を入力してください。")
+      end
+
+      it "without rating less than 0" do
+        review = build(:review, user_id: user.id, tourist_id: tourist.id, rating: -1)
+        review.valid?
+        expect(review.errors[:rating]).to include("評価は0以上5以下の数字を入力してください。")
+      end
+
+      it "duplicated review at same post by same tourist" do
+        FactoryBot.create(:review2, user_id: user.id, tourist_id: tourist.id)
+        review = build(:review, user_id: user.id, tourist_id: tourist.id)
+        review.valid?
+        expect(review.errors[:tourist_id]).to include("既にレビューが投稿されています。")
+      end
+    end
+  end
+
+  describe "self.review_static" do
+    it "any reviews isn't posted, returns 0" do
+      user = FactoryBot.create(:user)
+      static = Review.review_static(user.id)
+      expect(static[:average]).to eq 0.0
+      expect(static[:count]).to eq 0
+    end
+
+    it "some reviews is posted, returns {average: 3.0, count: 3}" do
+      user = FactoryBot.create(:user)
+      tourist1 = FactoryBot.create(:tourist)
+      tourist2 = FactoryBot.create(:tourist1)
+      tourist3 = FactoryBot.create(:tourist2)
+      reivew1 = FactoryBot.create(:review, user_id: user.id, tourist_id: tourist1.id)
+      reivew2 = FactoryBot.create(:review2, user_id: user.id, tourist_id: tourist2.id)
+      reivew3 = FactoryBot.create(:review3, user_id: user.id, tourist_id: tourist3.id)
+
+      static = Review.review_static(user.id)
+      expect(static[:average]).to eq 3.0
+      expect(static[:count]).to eq 3
+    end
+
+    it "some reviews is posted, returns {average: 2.0, count: 2}" do
+      user = FactoryBot.create(:user)
+      tourist1 = FactoryBot.create(:tourist)
+      tourist3 = FactoryBot.create(:tourist2)
+      reivew1 = FactoryBot.create(:review, user_id: user.id, tourist_id: tourist1.id)
+      reivew3 = FactoryBot.create(:review3, user_id: user.id, tourist_id: tourist3.id)
+
+      static = Review.review_static(user.id)
+      expect(static[:average]).to eq 2.0
+      expect(static[:count]).to eq 2
+    end
+  end
+
 end

--- a/spec/requests/api/v1/tourist/reviews_request_spec.rb
+++ b/spec/requests/api/v1/tourist/reviews_request_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Tourist::Reviews", type: :request do
+  describe "POST #create" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:tourist) { FactoryBot.create(:tourist) }
+
+    context "valid with parameter" do
+      it "responds successfully" do
+        post api_v1_tourist_reviews_url,
+            params: { review: FactoryBot.attributes_for(:review, user_id: user.id, tourist_id: tourist.id)},
+            headers: { Authorization: JsonWebToken.encode(tourist_id: tourist.id)}
+        expect(response).to have_http_status(:created)
+        json = JSON.parse(response.body)
+        expect(json["lang"]).to eq "ja"
+        expect(json["postReview"]).to eq "ここは最高によかった"
+        expect(json["rating"]).to eq 3
+      end
+
+      it "adds a review" do
+        expect{
+          post api_v1_tourist_reviews_url,
+            params: { review: FactoryBot.attributes_for(:review, user_id: user.id, tourist_id: tourist.id)},
+            headers: { Authorization: JsonWebToken.encode(tourist_id: tourist.id)}
+        }.to change(Review, :count).by(1)
+      end
+    end
+
+    context "invalid with parameter" do
+      it "responds 422 error" do
+        post api_v1_tourist_reviews_url,
+            params: { review: FactoryBot.attributes_for(:review, user_id: user.id, tourist_id: tourist.id, post_review: "")},
+            headers: { Authorization: JsonWebToken.encode(tourist_id: tourist.id)}
+        expect(response).to have_http_status "422"
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:tourist) { FactoryBot.create(:tourist) }
+    let(:review) { FactoryBot.create(:review, user_id: user.id, tourist_id: tourist.id) }
+
+    context "as authorized tourist" do
+      it "responds successfully" do
+        delete api_v1_tourist_review_url(review.id), headers: { Authorization: JsonWebToken.encode(tourist_id: tourist.id)}
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it "remove a review" do
+        review.reload
+        expect{
+          delete api_v1_tourist_review_url(review.id), headers: { Authorization: JsonWebToken.encode(tourist_id: tourist.id)}
+        }.to change(Review, :count).by(-1)
+      end
+    end
+
+    context "as unauthorized user(anonymous)" do
+      it "responds 403 error" do
+        delete api_v1_tourist_review_url(review.id)
+        expect(response).to have_http_status "403"
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/tourist/spots_request_spec.rb
+++ b/spec/requests/api/v1/tourist/spots_request_spec.rb
@@ -14,11 +14,24 @@ RSpec.describe "Api::V1::Tourist::Spots", type: :request do
       @multi_profile3 = create(:multi_profile3, user_id: @user3.id)
     end
 
+    let(:tourist) { FactoryBot.create(:tourist) }
+    let(:tourist2) { FactoryBot.create(:tourist2) }
+
     it "responds succesfully" do
       get api_v1_tourist_spots_url({})
       expect(response).to have_http_status(:success)
       json = JSON.parse(response.body)
       expect(json["data"].count).to eq 3
+    end
+
+    it "responds rating" do
+      FactoryBot.create(:review, user_id: @user1.id, tourist_id: tourist.id)
+      FactoryBot.create(:review2, user_id: @user1.id, tourist_id: tourist2.id)
+      get api_v1_tourist_spots_url({})
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json["data"][0]["profile"]["rating"]).to eq 4.0
+      expect(json["data"][0]["profile"]["ratingCount"]).to eq 2
     end
 
     it "succeeds to search by a category" do

--- a/spec/requests/api/v1/tourist/tourists_request_spec.rb
+++ b/spec/requests/api/v1/tourist/tourists_request_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "Api::V1::Tourist::Tourists", type: :request do
         post api_v1_tourist_tourists_url, params: { tourist: FactoryBot.attributes_for(:tourist1) }
         expect(response).to have_http_status(:created)
         json = JSON.parse(response.body)
-        p json
         expect(json["email"]).to eq "sample1@gmail.com"
       end
 


### PR DESCRIPTION
### 概要

ユーザー（観光者）がレビューを投稿できる機能を実装。また、観光地ごとにレビューの平均とレビュー数をレスポンスするようにActive model serializerに設定。
詳細は #44 参照。
