### PR TITLE
[fix]update image uploader to escape from other parameter validation

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -10,12 +10,25 @@ class Api::V1::ProfilesController < ApplicationController
   end
 
   def update
-    if @profile.update(profile_params)
-      profile_serializer = parse_json(@profile)
-      render json: profile_serializer, status: :ok
+    if params[:profile][:image_file]
+      logger.debug("PramsThumbnail: #{params[:profile][:telephone]}")
+      if @profile.update_attribute(:image_file, params[:profile][:image_file])
+        profile_serializer = parse_json(@profile)
+        render json: profile_serializer, status: :ok
+      else
+        logger.debug("Thumbnail can't be updated: #{@profile.errors.messages}")
+        logger.debug("#{params[:profile][:conpany_site]}")
+        logger.debug("#{params[:profile][:telephone]}")
+        render json: { errors: @profile.errors }, status: :unprocessable_entity
+      end
     else
-      logger.debug("Profile model isn't updated: #{@profile.errors.messages}")
-      render json: { errors: @profile.errors }, status: :unprocessable_entity
+      if @profile.update(profile_params)
+        profile_serializer = parse_json(@profile)
+        render json: profile_serializer, status: :ok
+      else
+        logger.debug("Profile model isn't updated: #{@profile.errors.messages}")
+        render json: { errors: @profile.errors }, status: :unprocessable_entity
+      end
     end
   end
 

--- a/app/controllers/api/v1/tourist/tourists_controller.rb
+++ b/app/controllers/api/v1/tourist/tourists_controller.rb
@@ -31,8 +31,7 @@ class Api::V1::Tourist::TouristsController < ApplicationController
 
   def update
     if params[:tourist][:image_file]
-      logger.debug("#{params[:tourist][:image_file]}")
-      if @tourist.update_attributes(image_file: params[:tourist][:image_file])
+      if @tourist.update_attribute(:image_file, params[:tourist][:image_file])
         tourist_serializer = parse_json(@tourist)
         render json: tourist_serializer, status: :ok
       else

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -1,8 +1,7 @@
 class JsonWebToken
   SECRET_KEY = Rails.application.secrets.secret_key_base.to_s
 
-  def self.encode(payload, exp = 24.hours.from_now)
-    payload[:exp] = exp.to_i
+  def self.encode(payload)
     JWT.encode(payload, SECRET_KEY)
   end
 

--- a/spec/requests/api/v1/profiles_request_spec.rb
+++ b/spec/requests/api/v1/profiles_request_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe "Api::V1::Profiles", type: :request do
         expect(@profile.reload.telephone).to eq "08059876453"
         expect(@profile.reload.company_site).to eq "https://goooo.com"
       end
+
+      it "with only image_file", focus:true do
+        @user1 = FactoryBot.create(:user)
+        @profile1 = FactoryBot.build(:profile, user_id: @user1.id, telephone: "", company_site: "")
+        @profile1.save(validate: false)
+        encoded_image = encode("sample_test.png")
+        patch api_v1_profile_url(@profile1.id),
+              params: { profile: {image_file: encoded_image} },
+              headers: { Authorization: JsonWebToken.encode(user_id: @user1.id)}
+        expect(response).to have_http_status(:success)
+      end
     end
 
     context "as unauthorized user(anonymous)" do


### PR DESCRIPTION
### 概要

サムネイル画像のみ更新する処理において、imageFileパラメータのみ設定するとupdateアクションにおいて他のパラメータのバリデーションエラーが生じる。そのためupdate_attributeを利用することで画像アップロード時にはバリデーションを回避する方法を利用した。

