### PR TITLE
[update]Update exhibit index controller to add the case without pagination

### DIFF
--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -16,12 +16,9 @@ class Picture < ApplicationRecord
         picture_params[:image_file].each do |picture|
           image_data = self.split_base64(picture.to_s)
           image_data_string = image_data[:data]
-          logger.debug(image_data_string)
           io = CarrierStringIO.new(Base64.decode64(image_data_string))
           new_picture = Picture.new(exhibit_id: exhibit_id, image: io)
-          logger.debug("before picture save")
           new_picture.save!
-          logger.debug("success picture save")
         end
       end
     rescue => exception

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -16,9 +16,12 @@ class Picture < ApplicationRecord
         picture_params[:image_file].each do |picture|
           image_data = self.split_base64(picture.to_s)
           image_data_string = image_data[:data]
+          logger.debug(image_data_string)
           io = CarrierStringIO.new(Base64.decode64(image_data_string))
           new_picture = Picture.new(exhibit_id: exhibit_id, image: io)
+          logger.debug("before picture save")
           new_picture.save!
+          logger.debug("success picture save")
         end
       end
     rescue => exception

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -21,6 +21,10 @@ if Rails.env.production?
   end
 else
   CarrierWave.configure do |config|
-    config.asset_host = 'http://0.0.0.0:80'
+    # local server settings
+    # config.asset_host = 'http://0.0.0.0:80'
+
+    # Actual machine test for iOS
+    config.asset_host = 'http://startlens.local'
   end
 end


### PR DESCRIPTION
### 概要

iOSアプリからのAPIエンドポイントとして、paginationのためのパラメータpageがない場合のレスポンス処理を追加。iOSアプリからはページネーションによるリクエスト処理とUXを考慮しないため一度に全てのrecordを取得できるように実装した。